### PR TITLE
modify parse_tres to deal with gpu:V100:1 case

### DIFF
--- a/sq.py
+++ b/sq.py
@@ -266,8 +266,11 @@ def parse_tres(tres_str):
             key, value = kv.split('=')
             tres[key] = int(value)
         if ':' in kv:
-            key, value = kv.split(':')
-            tres[key] = int(value)
+            tmp = kv.split(':')
+            # Modified to account for "gres:V100:2"
+            # key, value = kv.split(':')
+            key = tmp[0]
+            tres[key] = int(tmp[-1])  # int(value)
     return tres
 
 def parse_tres_nodes(nodes, tres_per_node, other):


### PR DESCRIPTION
This fixes the issue that was flagged in [INC1453651](https://berkeley.service-now.com/nav_to.do?uri=incident.do%3Fsys_id=8f8c56981b2f1150d1d132af034bcb41%26sysparm_stack=incident_list.do%3Fsysparm_query=active=true)