### PR TITLE
fix bug when Latin1 character is part of `squeue` output

### DIFF
--- a/sq.py
+++ b/sq.py
@@ -16,7 +16,7 @@ def run_cmd(cmd):
         proc = await asyncio.create_subprocess_shell(
             shlex.join(cmd), stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE)
         stdout, stderr = await proc.communicate()
-        return stdout.decode('utf-8')
+        return stdout.decode('utf-8', 'backslashreplace')
     return asyncio.run(inner())
 
 def freeze(dest_dir, name, data):


### PR DESCRIPTION
This modifies how we call `decode('utf-8')` to handle cases where a non-UTF-8 character is present.

@wfeinstein could you prioritize merging this in and updating `sq` on Savio -- currently `sq` is broken for all users because a single user's job involves a latin1 character